### PR TITLE
コメント投稿機能の不具合修正

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,4 +1,6 @@
 class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :item
+
+  validates :text, presence: true
 end


### PR DESCRIPTION
#What
commentモデルに空入力不可となるバリデーションを設定。

#Why
空欄でのコメント投稿をできないようにするため